### PR TITLE
check how colliding path-dependent types are handled

### DIFF
--- a/scalafix-rules/src/main/scala/scala/meta/internal/pc/ScalafixGlobal.scala
+++ b/scalafix-rules/src/main/scala/scala/meta/internal/pc/ScalafixGlobal.scala
@@ -238,7 +238,18 @@ class ScalafixGlobal(
             // "scala.Seq[T]" even when it's needed.
             loop(ThisType(sym.owner), name)
           } else if (sym.hasPackageFlag || sym.isPackageObjectOrClass) {
-            if (history.tryShortenName(name)) NoPrefix
+            // Use the prefix rather than the real owner to maximize the
+            // chances of shortening the reference: when `name` is directly
+            // nested in a non-statically addressable type (class or trait),
+            // its original owner is that type (requiring a type projection
+            // to reference it) while the prefix is its concrete owner value
+            // (for which the dot syntax works).
+            // https://docs.scala-lang.org/tour/inner-classes.html
+            // https://danielwestheide.com/blog/the-neophytes-guide-to-scala-part-13-path-dependent-types/
+            val dotSyntaxFriendlyName = name
+              .map(_.symbol.cloneSymbol(sym))
+              .map(ShortName.apply)
+            if (history.tryShortenName(dotSyntaxFriendlyName)) NoPrefix
             else tpe
           } else {
             if (history.isSymbolInScope(sym, pre)) SingleType(NoPrefix, sym)

--- a/scalafix-tests/input/src/main/scala/test/explicitResultTypes/PathDependentTypes.scala
+++ b/scalafix-tests/input/src/main/scala/test/explicitResultTypes/PathDependentTypes.scala
@@ -20,7 +20,12 @@ class Clazz {
 package object PackageObject extends Trait
 
 package pkg {
-  object Obj extends Clazz
+  abstract class AbstractClazz {
+    trait Baz
+  }
+  object Obj extends Clazz {
+    object NestedObj extends AbstractClazz
+  }
 }
 
 trait PathDependentTypes {
@@ -33,4 +38,7 @@ trait PathDependentTypes {
 
   def qux: pkg.Obj.Qux = ???
   val quxRef = qux
+
+  def baz: pkg.Obj.NestedObj.Baz = ???
+  val bazRef = baz
 }

--- a/scalafix-tests/input/src/main/scala/test/explicitResultTypes/PathDependentTypes.scala
+++ b/scalafix-tests/input/src/main/scala/test/explicitResultTypes/PathDependentTypes.scala
@@ -19,6 +19,8 @@ class Clazz {
 // like https://github.com/tpolecat/doobie/blob/c2e0445/modules/core/src/main/scala/doobie/hi/package.scala#L25
 package object PackageObject extends Trait
 
+package object PackageObject2 extends Trait
+
 package pkg {
   abstract class AbstractClazz {
     trait Baz
@@ -32,6 +34,9 @@ trait PathDependentTypes {
   // like https://github.com/tpolecat/doobie/blob/c2e0445/modules/core/src/main/scala/doobie/util/query.scala#L163
   def foo: PackageObject.Foo = ???
   val fooRef = foo
+
+  def foo2: PackageObject2.Foo = ???
+  val foo2Ref = foo2
 
   def bar: PackageObject.Nested.Bar = ???
   val barRef = bar

--- a/scalafix-tests/input/src/main/scala/test/explicitResultTypes/PathDependentTypes.scala
+++ b/scalafix-tests/input/src/main/scala/test/explicitResultTypes/PathDependentTypes.scala
@@ -1,0 +1,36 @@
+/*
+rules = ExplicitResultTypes
+ExplicitResultTypes.skipSimpleDefinitions = ["Lit"]
+*/
+package test.explicitResultTypes
+
+// like https://github.com/tpolecat/doobie/blob/c2e044/modules/core/src/main/scala/doobie/free/Aliases.scala#L10
+trait Trait {
+  class Foo // like https://github.com/tpolecat/doobie/blob/c2e0445/modules/core/src/main/scala/doobie/free/Aliases.scala#L14
+  object Nested {
+    class Bar
+  }
+}
+
+class Clazz {
+  trait Qux
+}
+
+// like https://github.com/tpolecat/doobie/blob/c2e0445/modules/core/src/main/scala/doobie/hi/package.scala#L25
+package object PackageObject extends Trait
+
+package pkg {
+  object Obj extends Clazz
+}
+
+trait PathDependentTypes {
+  // like https://github.com/tpolecat/doobie/blob/c2e0445/modules/core/src/main/scala/doobie/util/query.scala#L163
+  def foo: PackageObject.Foo = ???
+  val fooRef = foo
+
+  def bar: PackageObject.Nested.Bar = ???
+  val barRef = bar
+
+  def qux: pkg.Obj.Qux = ???
+  val quxRef = qux
+}

--- a/scalafix-tests/input/src/main/scala/tests/ExplicitResultTypesImports.scala
+++ b/scalafix-tests/input/src/main/scala/tests/ExplicitResultTypesImports.scala
@@ -16,7 +16,6 @@ object ExplicitResultTypesImports {
 
   val timezone = null.asInstanceOf[java.util.TimeZone]
 
-  // TODO: Is this desirable behavior?
   val inner = null.asInstanceOf[scala.collection.Searching.SearchResult]
 
   final val javaEnum = java.util.Locale.Category.DISPLAY

--- a/scalafix-tests/output/src/main/scala/test/explicitResultTypes/PathDependentTypes.scala
+++ b/scalafix-tests/output/src/main/scala/test/explicitResultTypes/PathDependentTypes.scala
@@ -1,0 +1,32 @@
+package test.explicitResultTypes
+
+// like https://github.com/tpolecat/doobie/blob/c2e044/modules/core/src/main/scala/doobie/free/Aliases.scala#L10
+trait Trait {
+  class Foo // like https://github.com/tpolecat/doobie/blob/c2e0445/modules/core/src/main/scala/doobie/free/Aliases.scala#L14
+  object Nested {
+    class Bar
+  }
+}
+
+class Clazz {
+  trait Qux
+}
+
+// like https://github.com/tpolecat/doobie/blob/c2e0445/modules/core/src/main/scala/doobie/hi/package.scala#L25
+package object PackageObject extends Trait
+
+package pkg {
+  object Obj extends Clazz
+}
+
+trait PathDependentTypes {
+  // like https://github.com/tpolecat/doobie/blob/c2e0445/modules/core/src/main/scala/doobie/util/query.scala#L163
+  def foo: PackageObject.Foo = ???
+  val fooRef: test.explicitResultTypes.PackageObject.Foo = foo
+
+  def bar: PackageObject.Nested.Bar = ???
+  val barRef: test.explicitResultTypes.PackageObject.Nested.Bar = bar
+
+  def qux: pkg.Obj.Qux = ???
+  val quxRef: test.explicitResultTypes.pkg.Obj.Qux = qux
+}

--- a/scalafix-tests/output/src/main/scala/test/explicitResultTypes/PathDependentTypes.scala
+++ b/scalafix-tests/output/src/main/scala/test/explicitResultTypes/PathDependentTypes.scala
@@ -1,5 +1,6 @@
 package test.explicitResultTypes
 
+import test.explicitResultTypes.PackageObject.{ Foo, Nested }
 // like https://github.com/tpolecat/doobie/blob/c2e044/modules/core/src/main/scala/doobie/free/Aliases.scala#L10
 trait Trait {
   class Foo // like https://github.com/tpolecat/doobie/blob/c2e0445/modules/core/src/main/scala/doobie/free/Aliases.scala#L14
@@ -22,10 +23,10 @@ package pkg {
 trait PathDependentTypes {
   // like https://github.com/tpolecat/doobie/blob/c2e0445/modules/core/src/main/scala/doobie/util/query.scala#L163
   def foo: PackageObject.Foo = ???
-  val fooRef: test.explicitResultTypes.PackageObject.Foo = foo
+  val fooRef: Foo = foo
 
   def bar: PackageObject.Nested.Bar = ???
-  val barRef: test.explicitResultTypes.PackageObject.Nested.Bar = bar
+  val barRef: Nested.Bar = bar
 
   def qux: pkg.Obj.Qux = ???
   val quxRef: test.explicitResultTypes.pkg.Obj.Qux = qux

--- a/scalafix-tests/output/src/main/scala/test/explicitResultTypes/PathDependentTypes.scala
+++ b/scalafix-tests/output/src/main/scala/test/explicitResultTypes/PathDependentTypes.scala
@@ -17,6 +17,8 @@ class Clazz {
 // like https://github.com/tpolecat/doobie/blob/c2e0445/modules/core/src/main/scala/doobie/hi/package.scala#L25
 package object PackageObject extends Trait
 
+package object PackageObject2 extends Trait
+
 package pkg {
   abstract class AbstractClazz {
     trait Baz
@@ -30,6 +32,9 @@ trait PathDependentTypes {
   // like https://github.com/tpolecat/doobie/blob/c2e0445/modules/core/src/main/scala/doobie/util/query.scala#L163
   def foo: PackageObject.Foo = ???
   val fooRef: Foo = foo
+
+  def foo2: PackageObject2.Foo = ???
+  val foo2Ref: PackageObject2.Foo = foo2
 
   def bar: PackageObject.Nested.Bar = ???
   val barRef: Nested.Bar = bar

--- a/scalafix-tests/output/src/main/scala/test/explicitResultTypes/PathDependentTypes.scala
+++ b/scalafix-tests/output/src/main/scala/test/explicitResultTypes/PathDependentTypes.scala
@@ -1,6 +1,7 @@
 package test.explicitResultTypes
 
 import test.explicitResultTypes.PackageObject.{ Foo, Nested }
+import test.explicitResultTypes.pkg.Obj
 // like https://github.com/tpolecat/doobie/blob/c2e044/modules/core/src/main/scala/doobie/free/Aliases.scala#L10
 trait Trait {
   class Foo // like https://github.com/tpolecat/doobie/blob/c2e0445/modules/core/src/main/scala/doobie/free/Aliases.scala#L14
@@ -17,7 +18,12 @@ class Clazz {
 package object PackageObject extends Trait
 
 package pkg {
-  object Obj extends Clazz
+  abstract class AbstractClazz {
+    trait Baz
+  }
+  object Obj extends Clazz {
+    object NestedObj extends AbstractClazz
+  }
 }
 
 trait PathDependentTypes {
@@ -29,5 +35,8 @@ trait PathDependentTypes {
   val barRef: Nested.Bar = bar
 
   def qux: pkg.Obj.Qux = ???
-  val quxRef: test.explicitResultTypes.pkg.Obj.Qux = qux
+  val quxRef: Obj.Qux = qux
+
+  def baz: pkg.Obj.NestedObj.Baz = ???
+  val bazRef: Obj.NestedObj.Baz = baz
 }

--- a/scalafix-tests/output/src/main/scala/tests/ExplicitResultTypesImports.scala
+++ b/scalafix-tests/output/src/main/scala/tests/ExplicitResultTypesImports.scala
@@ -18,7 +18,6 @@ object ExplicitResultTypesImports {
 
   val timezone: ju.TimeZone = null.asInstanceOf[java.util.TimeZone]
 
-  // TODO: Is this desirable behavior?
   val inner: Searching.SearchResult = null.asInstanceOf[scala.collection.Searching.SearchResult]
 
   final val javaEnum: Category = java.util.Locale.Category.DISPLAY


### PR DESCRIPTION
```diff
--- obtained
+++ expected
@@ -36,3 +36,3 @@
   def foo2: PackageObject2.Foo = ???
-  val foo2Ref: Foo = foo2
+  val foo2Ref: PackageObject2.Foo = foo2
```

But compiling with `val foo2Ref: Foo = foo2` shows that `isKindaTheSameAs` brings false positives:
```
[error] /home/bjaglin/git/projects/scalafix/scalafix-tests/output/src/main/scala/test/explicitResultTypes/PathDependentTypes.scala:37:22: type mismatch;
[error]  found   : test.explicitResultTypes.PackageObject2.Foo
[error]  required: test.explicitResultTypes.PackageObject.Foo
[error]   val foo2Ref: Foo = foo2
[error]                      ^
```